### PR TITLE
Docker compose w/ CAD software

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,49 @@
+version: '3.8'
+
+services:
+  kicad:
+    image: linuxserver/kicad
+    container_name: kicad
+    environment:
+      - PUID=1000  
+      - PGID=1000 
+      - TZ=America/New_York 
+    volumes:
+      - ./kicad/config:/config
+      - ./kicad/projects:/projects
+    ports:
+      - 3001:3000 
+    restart: unless-stopped
+
+  freecad:
+    image: linuxserver/freecad
+    container_name: freecad
+    environment:
+      - PUID=1000  
+      - PGID=1000  
+      - TZ=America/New_York  
+    volumes:
+      - ./freecad/config:/config
+      - ./freecad/projects:/projects
+    ports:
+      - 3002:3000  
+    restart: unless-stopped
+
+  blender:
+    image: linuxserver/blender
+    container_name: blender
+    environment:
+      - PUID=1000  
+      - PGID=1000  
+      - TZ=America/New_York  
+    volumes:
+      - ./blender/config:/config
+      - ./blender/projects:/projects
+    ports:
+      - 3003:3000  
+    restart: unless-stopped
+
+networks:
+  default:
+    driver: bridge
+


### PR DESCRIPTION
Because people love self hosting stuff in browser, `linuxserver` offers a bunch of images of this software just available in docker containers that we can expose through docker compose interfaces. If you want to boot all of the services at once, run `docker compose run` or add the `-d` flag to detach it from your terminal. This is cross platform and we can configure them to pull from specific directories.

This will be useful to fiddling around with CI/CD pipelines for rendering PCBs and exporting STEP files. I also wonder if we can just supply a docker compose with a kicad docker container service instead of requiring people to install a specific version, since versioning KiCAD kinda sucks at times. Maybe we can also provide a nice way of installing some default plugins or something idk. I feel like this has potential